### PR TITLE
qcom-common: allow mQANElements to be over-rided

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/SonyRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/SonyRIL.java
@@ -16,12 +16,13 @@
 
 package com.android.internal.telephony;
 
+import android.os.SystemProperties;
 import android.content.Context;
 
 public class SonyRIL extends RIL implements CommandsInterface {
     public SonyRIL(Context context, int networkMode, int cdmaSubscription, Integer instanceId) {
         super(context, networkMode, cdmaSubscription, instanceId);
 
-        mQANElements = 5;
+        mQANElements = SystemProperties.getInt("ro.ril.telephony.mqanelements", 5);
     }
 }


### PR DESCRIPTION
Not all RIL blobs supply multiple of 5 strings. Allow it to be changed by a property

Change-Id: I0135768ae9b439b08278afb49ba91db3fb2dd463
Signed-off-by: Varun Chitre <varun.chitre15@gmail.com>